### PR TITLE
Remove reference to OS X Mavericks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,7 @@ text.update(.Success(Box("World")))
 
 ## Installation
 
-> **Embedded frameworks require a minimum deployment target of iOS 8 or OS X Mavericks.**
+> **Dynamic frameworks on iOS require a minimum deployment target of iOS 8 or later.**
 >
 > To use Interstellar with a project targeting iOS 7, you must include all Swift files directly in your project.
 


### PR DESCRIPTION
This sentence was confusing — OS X has support dynamic frameworks since version 10.0. Also renamed from "embedded" to "dynamic" as the ability of a framework to be embedded has little to do with the problem – it's actually the dynamic nature of the framework that requires iOS 8+.
