### PR TITLE
Renames Result.Error to Result.Failure

### DIFF
--- a/Interstellar/Result.swift
+++ b/Interstellar/Result.swift
@@ -29,7 +29,7 @@
 */
 public enum Result<T> {
     case Success(T)
-    case Error(ErrorType)
+    case Failure(ErrorType)
     
     /**
         Transform a result into another result using a function. If the result was an error,
@@ -38,7 +38,7 @@ public enum Result<T> {
     public func map<U>(f: T -> U) -> Result<U> {
         switch self {
         case let .Success(v): return .Success(f(v))
-        case let .Error(error): return .Error(error)
+        case let .Failure(error): return .Failure(error)
         }
     }
     
@@ -52,7 +52,7 @@ public enum Result<T> {
             case let .Success(v): f(v){ transformed in
                     g(.Success(transformed))
                 }
-            case let .Error(error): g(.Error(error))
+            case let .Failure(error): g(.Failure(error))
             }
         }
     }
@@ -64,7 +64,7 @@ public enum Result<T> {
     public func flatMap<U>(f: T -> Result<U>) -> Result<U> {
         switch self {
         case let .Success(v): return f(v)
-        case let .Error(error): return .Error(error)
+        case let .Failure(error): return .Failure(error)
         }
     }
     
@@ -77,7 +77,7 @@ public enum Result<T> {
             do {
                 return .Success(try f(t))
             } catch let error {
-                return .Error(error)
+                return .Failure(error)
             }
         }
     }
@@ -89,7 +89,7 @@ public enum Result<T> {
         return { g in
             switch self {
             case let .Success(v): f(v, g)
-            case let .Error(error): g(.Error(error))
+            case let .Failure(error): g(.Failure(error))
             }
         }
     }
@@ -119,7 +119,7 @@ public enum Result<T> {
     public var value: T? {
         switch self {
         case let .Success(v): return v
-        case .Error(_): return nil
+        case .Failure(_): return nil
         }
     }
 }

--- a/Interstellar/Signal.swift
+++ b/Interstellar/Signal.swift
@@ -132,7 +132,7 @@ public final class Signal<T> {
                 if f(value) {
                     signal.update(result)
                 }
-            case let .Error(error): signal.update(.Error(error))
+            case let .Failure(error): signal.update(.Failure(error))
             }
         }
         return signal
@@ -146,21 +146,21 @@ public final class Signal<T> {
         subscribe { result in
             switch(result) {
             case let .Success(value): g(value)
-            case .Error(_): return
+            case .Failure(_): return
             }
         }
         return self
     }
     
     /**
-        Subscribe to the changes of this signal (.Error only).
+        Subscribe to the changes of this signal (.Failure only).
         This method is chainable.
     */
     public func error(g: ErrorType -> Void) -> Signal<T> {
         subscribe { result in
             switch(result) {
             case .Success(_): return
-            case let .Error(error): g(error)
+            case let .Failure(error): g(error)
             }
         }
         return self
@@ -188,7 +188,7 @@ public final class Signal<T> {
             }
         }
         let errorHandler = { (error: ErrorType) in
-            signal.update(.Error(error))
+            signal.update(.Failure(error))
         }
         self.error(errorHandler)
         merge.error(errorHandler)
@@ -219,7 +219,7 @@ public final class Signal<T> {
      about the new value.
      */
     public func update(error: ErrorType) {
-        update(.Error(error))
+        update(.Failure(error))
     }
     
     /**

--- a/InterstellarTests/InterstellarTests.swift
+++ b/InterstellarTests/InterstellarTests.swift
@@ -16,7 +16,7 @@ class InterstellarTests: XCTestCase {
             return .Success("Hello \(subject)")
         } else {
             let error: NSError = NSError(domain: "No one to greet!", code: 404, userInfo: nil)
-            return .Error(error)
+            return .Failure(error)
         }
     }
     

--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ func greetMaybe(subject: String)->Result<String> {
         return .Success("Hello \(subject)")
     } else {
         let error = NSError(domain: "Don't feel like greeting you.", code: 401, userInfo: nil)
-        return .Error(error)
+        return .Failure(error)
     }
 }
 text.flatMap(greetMaybe)
@@ -99,7 +99,7 @@ func greetMaybe(subject: String, completion: Result<String>->Void) {
         completion(.Success("Hello \(subject)"))
     } else {
         let error = NSError(domain: "Don't feel like greeting you.", code: 401, userInfo: nil)
-        completion(.Error(error))
+        completion(.Failure(error))
     }
 }
 text.flatMap(greetMaybe)

--- a/Warpdrive/Waiting.swift
+++ b/Warpdrive/Waiting.swift
@@ -54,7 +54,7 @@ public extension Signal {
         }
         switch result! {
         case let .Success(t): return t
-        case let .Error(e): throw e
+        case let .Failure(e): throw e
         }
     }
 }


### PR DESCRIPTION
This is a cosmetic change that disambiguates the `Error` case of the `Result` enum from the `error` value.
Success and failure are better antonyms than success and error.

(Unit tests & README also updated)
