### PR TITLE
Add missing Foundation import for NSError.

### DIFF
--- a/Interstellar.playground/Pages/4 Handle errors in sequences of functions.xcplaygroundpage/Contents.swift
+++ b/Interstellar.playground/Pages/4 Handle errors in sequences of functions.xcplaygroundpage/Contents.swift
@@ -2,6 +2,7 @@
 
 //: Handle errors in sequences of functions
 
+import Foundation
 import Interstellar
 
 let text = Signal<String>()


### PR DESCRIPTION
Page 4 of the playground was failing to compile due to a missing import.
