### PR TITLE
Use pthread_mutex for locking

### DIFF
--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -126,7 +126,9 @@ public final class Signal<T> {
         if let value = value {
             f(value)
         }
-        callbacks.append(f)
+        lock.sync {
+            callbacks.append(f)
+        }
         return self
     }
     


### PR DESCRIPTION
Use a `pthread_mutex_t` to synchronise access to the callbacks instead of `objc_sync_{enter,exit}` which is only available on Darwin. 

Furthermore, also synchronise when adding new subscribers.

Haven't actually tried this on a Linux build of Swift, since I don't have one.
