### PR TITLE
Haskell Style FlatMap

### DIFF
--- a/Interstellar.playground/Pages/6 Using flatMap on signals of signals.xcplaygroundpage/Contents.swift
+++ b/Interstellar.playground/Pages/6 Using flatMap on signals of signals.xcplaygroundpage/Contents.swift
@@ -1,0 +1,79 @@
+//: [Previous](@previous)
+
+import Foundation
+import Interstellar
+
+/*: 
+It's your first day at Space Inc, and you've been given the job to write some code
+to refuel an orbiting space station.  There's already been some code written, and
+at the center of this code are Signals.
+
+Talking to the space station, takes a lot of time.  Commands need to be send via a
+radio tower and then results returned to the radio tower.  These kind of operations
+are perfect to be Signals- they return values... eventually.
+*/
+
+/// Get fuel levels for the space station
+/// Returns an Int for the fuel level
+func getFuelLevelsFromSpaceStation() -> Signal<Int> {
+    // In this stub implementation we return a value right away
+    return Signal(255)
+}
+
+/// Sends the command to open the fuel port
+/// Returns a bool representing if the fuel port is open (true) or closed (false)
+func openFuelPort() -> Signal<Bool> {
+    // In this stub implementation we return a value right away
+    return Signal(true)
+}
+
+/// Sends the command to refuel from a fuel pack
+/// WARNING: Make sure the fuel port is open before you do this!
+/// WARNING: The space station can only contain 1000 fuel units
+/// Returns an Int representing the fuel level for the space station
+func refuelSpaceStationFromFuelPack(fuelPackSize: Int) -> Signal<Int> {
+    // In this stub implementation we return a value right away
+    return Signal(255 + fuelPackSize)
+}
+
+
+/*:
+We've been tasked with taking this library code and writing a refueling function.
+This is a perfect case for `flatMap`.
+
+flatMap is a tool that takes a function that returns a signal and returns its inner
+Signals values.
+
+Let's start by getting the fuel level and opening the opening the fuel port
+*/
+
+let fuelPackSize = 500
+getFuelLevelsFromSpaceStation()
+    .flatMap { fuelLevel -> Signal<Bool> in
+        if (fuelLevel) < 500 {
+            return openFuelPort()
+        }
+        return Signal(false)
+    }
+    .flatMap { fuelPortIsOpen -> Signal<Int> in
+        if fuelPortIsOpen {
+            return refuelSpaceStationFromFuelPack(fuelPackSize)
+        }
+        return Signal(0)
+    }
+    .next { spaceStationFuel in
+        print("The space station now has \(spaceStationFuel) fuel units available")
+    }
+
+// The result of running the above code is:
+// The space station now has 755 fuel units available
+
+/*:
+Notice how the inner blocks return a signal but the next blocks reference the value that
+is returned by the innerSignal.
+
+`flatMap` is a wonderful tool when you are dealing with multiple asynchrous operations that
+need to be chained
+*/
+
+//: [Next](@next)

--- a/Interstellar.playground/Pages/6 Using flatMap on signals of signals.xcplaygroundpage/timeline.xctimeline
+++ b/Interstellar.playground/Pages/6 Using flatMap on signals of signals.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Interstellar.playground/contents.xcplayground
+++ b/Interstellar.playground/contents.xcplayground
@@ -7,5 +7,6 @@
         <page name='3 Use functions as transforms'/>
         <page name='4 Handle errors in sequences of functions'/>
         <page name='5 This also works for asynchronous functions'/>
+        <page name='6 Using flatMap on signals of signals'/>
     </pages>
 </playground>

--- a/Readme.md
+++ b/Readme.md
@@ -123,6 +123,35 @@ text
 text.update(.Success("World"))
 ```
 
+## FlatMapping across a signal that returns signals
+
+```swift
+let baseCost = Signal<Int>()
+
+
+let total = baseCost
+    .flatMap { base in
+        // Marks up the price
+        return Signal(base * 2)
+    }
+    .map { amount in
+        // Adds sales tax
+        return Double(amount) * 1.09
+    }
+
+total.next { total in
+    print("Your total is: \(total)")
+}
+
+baseCost.update(10)
+baseCost.update(122)
+
+/* Output:
+Your total is: 21.8
+Your total is: 265.96
+*/
+```
+
 ---
 
 ## Communication

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -99,6 +99,26 @@ public final class Signal<T> {
     }
     
     /**
+        Transform the signal into another signal using a function, return the
+        value of the inner signal
+    */
+    public func flatMap<U>(f: (T -> Signal<U>)) -> Signal<U> {
+        let signal = Signal<U>()
+        subscribe { result in
+            switch(result) {
+            case let .Success(value):
+                let innerSignal = f(value)
+                innerSignal.subscribe { innerResult in
+                    signal.update(innerResult)
+                }
+            case let .Error(error):
+                signal.update(.Error(error))
+            }
+        }
+        return signal
+    }
+    
+    /**
         Call a function with the result as an argument. Use this if the function should be
         executed no matter if the signal is a success or not.
         This method can also be used to convert an .Error into a .Success which might be handy

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -40,6 +40,13 @@ class SignalTests: XCTestCase {
         XCTAssertEqual(greeting, "Hello World")
     }
     
+    func testFlatMappingASignal() {
+        let greeting = Signal("Hello").flatMap { greeting in
+            Signal(greeting + " World")
+        }.peek()
+        XCTAssertEqual(greeting, "Hello World")
+    }
+    
     func testError() {
         let greeting = Signal("").flatMap(greeter).peek()
         XCTAssertNil(greeting)


### PR DESCRIPTION
This PR adds a haskell style flatMap
## Motivation

This adds a flatMap that works the way that [other stream of values over time](https://github.com/ReactiveCocoa/ReactiveCocoa) implementations work.  Specifically it let a Signal that returns a Signal flatMap so that the next block gets the inner values.

This style of flatMap was request in [PR #15](https://github.com/JensRavens/Interstellar/issues/15)

@b123400 mentioned that

> the idea of flatMap from Haskell, which is >>=.
> The flatMapping function should expect a function that returns a signal, which means
> 
> flatMap<U> : ( T -> Signal<U> ) -> Signal <U>
> Because Result<U> is not a Signal<U>, it is not flatMapping. To be accurate, the current flatMap function is flatting a Result, but mapping a Signal, which is not what a signal should be doing.
> 
> If you want to add error handling to signal, it should be a Signal<Result<T>>.
> If you want a error stream, you can use filter to transfrom a Signal<Result<T>> to a Signal<T>.
> 
> The current implementation of Signal is actually 2 signals combined, one for Result.Success and one fore Result.Error
## A quick Example

Here's a toy example to show flatMap and map working together:

``` swift
let baseCost = Signal<Int>()


let total = baseCost
    .flatMap { base in
        // Marks up the price
        return Signal(base * 2)
    }
    .map { amount in
        // Adds sales tax
        return Double(amount) * 1.09
    }

total.next { total in
    print("Your total is: \(total)")
}

baseCost.update(10)
baseCost.update(122)

/* Output:
Your total is: 21.8
Your total is: 265.96
*/
```

A more complete example can be seen in the playground attached to this PR.
## Work Done
- [X] Add flatMap implementation
- [X] Add documentation about flatMap
  - [X] Update Readme
  - [X] Update playground
- [X] Add a test
- [X] Pull Request description
## Work Left Not Done
- Refactoring existing flatMap, map into "then" API
