### PR TITLE
Moves public unsubscription to observer token.

### DIFF
--- a/Tests/ObservableTests.swift
+++ b/Tests/ObservableTests.swift
@@ -74,7 +74,7 @@ class ObservableTests: XCTestCase {
             count += 1
         }
         observable.update("Hello")
-        observable.unsubscribe(token)
+        token.unsubscribe()
         observable.update("Hello")
         XCTAssertEqual(count, 1)
     }


### PR DESCRIPTION
This is a first-pass, happy to amend based on any feedback. Changed the existing tests to support the new behaviour. If this looks good to you, I'll update the documentation, too.

Fixes #40.
