### PR TITLE
Re-adds unsubscribe() to ObserverToken.

### DIFF
--- a/Sources/ObserverToken.swift
+++ b/Sources/ObserverToken.swift
@@ -19,14 +19,20 @@
 // THE SOFTWARE.
 
 /// Observer tokens are created by observables to hande unsubscription. You are not supposed to create them directly.
-public final class ObserverToken: Hashable {
+public final class ObserverToken<T>: Hashable {
     public let hashValue: Int
+    private weak var observable: Observable<T>?
     
-    internal init (hashValue: Int) {
+    internal init (hashValue: Int, observable: Observable<T>?) {
         self.hashValue = hashValue
+        self.observable = observable
+    }
+
+    public func unsubscribe() {
+        observable?.unsubscribe(self)
     }
 }
 
-public func ==(lhs: ObserverToken, rhs: ObserverToken) -> Bool {
+public func ==<T>(lhs: ObserverToken<T>, rhs: ObserverToken<T>) -> Bool {
     return lhs.hashValue == rhs.hashValue
 }

--- a/Tests/InterstellarTests/ObservableTests.swift
+++ b/Tests/InterstellarTests/ObservableTests.swift
@@ -78,6 +78,18 @@ class ObservableTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
+    func testObservableTokenUnsubscribe() {
+        let observable = Observable<String>()
+        var count = 0
+        let token = observable.subscribe { a in
+            count += 1
+        }
+        observable.update("Hello")
+        token.unsubscribe()
+        observable.update("Hello")
+        XCTAssertEqual(count, 1)
+    }
+
     func testMergeInvocations() {
         let lhs = Observable<String>()
         let rhs = Observable<String>()


### PR DESCRIPTION
Related to #43. See comment here: https://github.com/JensRavens/Interstellar/commit/23cbec94a1bdba01ed88a5db360767d46dd2abc1 but essentially unsubscribing using only the observer token appears to have been removed in the Swift 3 update. This PR adds it back in.