### PR TITLE
Silenced warning on Xcode 10.

### DIFF
--- a/Sources/Interstellar/Mutex.swift
+++ b/Sources/Interstellar/Mutex.swift
@@ -34,7 +34,7 @@ internal class Mutex {
     
     func lock(_ closure: () -> Void) {
         let status = lock()
-        assert(status == 0, "pthread_mutex_lock: \(strerror(status))")
+        assert(status == 0, "pthread_mutex_lock: \(String(describing: strerror(status)))")
         defer { unlock() }
         closure()
     }


### PR DESCRIPTION
Let me know if this is ok or would you like to provide e.g default value instead. (`strerror(status)` returns optional)