### PR TITLE
Use recursive mutex for locking

### DIFF
--- a/Sources/Interstellar/Mutex.swift
+++ b/Sources/Interstellar/Mutex.swift
@@ -15,9 +15,12 @@ import Foundation
 
 internal class Mutex {
     fileprivate var mutex = pthread_mutex_t()
-    
+    fileprivate var attributes = pthread_mutexattr_t()
+
     init() {
-        pthread_mutex_init(&mutex, nil)
+        pthread_mutexattr_init(&attributes)
+        pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE)
+        pthread_mutex_init(&mutex, &attributes)
     }
     
     deinit {


### PR DESCRIPTION
Use `pthread_mutexattr_t` with `PTHREAD_MUTEX_RECURSIVE` attribute set to create mutex. This is required to prevent deadlock.

This behavior may occur e.g. if observer is removed from update method.

```
var token: ObserverToken!
let observable = Observable<Int>()
token = observable.subscribe { value in
  print(value)
  if value == 5 {
    // Deadlock
    observable.unsubscribe(token)
  }
}
observable.update(10)
observable.update(5)
```