### PR TITLE
Add unsubscribe to ObserverToken

### DIFF
--- a/Sources/Interstellar/ObserverToken.swift
+++ b/Sources/Interstellar/ObserverToken.swift
@@ -20,10 +20,16 @@
 
 /// Observer tokens are created by observables to hande unsubscription. You are not supposed to create them directly.
 public final class ObserverToken: Hashable {
+    public private(set) weak var observable: AnyObservable?
     public let hashValue: Int
     
-    internal init (hashValue: Int) {
+    internal init (observable: AnyObservable, hashValue: Int) {
+        self.observable = observable
         self.hashValue = hashValue
+    }
+    
+    public func unsubscribe() {
+        observable?.unsubscribe(self)
     }
 }
 

--- a/Tests/InterstellarTests/ObservableTests.swift
+++ b/Tests/InterstellarTests/ObservableTests.swift
@@ -77,6 +77,18 @@ class ObservableTests: XCTestCase {
         observable.update("Hello")
         XCTAssertEqual(count, 1)
     }
+    
+    func testTokenUnsubscribe() {
+        let observable = Observable<String>()
+        var count = 0
+        let token = observable.subscribe { a in
+            count += 1
+        }
+        observable.update("Hello")
+        token.unsubscribe()
+        observable.update("Hello")
+        XCTAssertEqual(count, 1)
+    }
 
     func testMergeInvocations() {
         let lhs = Observable<String>()


### PR DESCRIPTION
This simplifies the API for the observer, in case they need to unsubscribe without having direct access to the observable.

Please let me know if you'd like any changes to be made, also feel free to push changes directly as well.

Fixes #70 